### PR TITLE
Not zip-safe

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ setup(
     license = 'Apache 2.0',
     include_package_data = True,
     install_requires=read_file('requirements.txt'),
+    zip_safe = False,
     classifiers = [
     ],
 )


### PR DESCRIPTION
Added zip_safe = False to setup.py because it doesn't play nice with buildout and eggs. (regarding templates)
