### PR TITLE
Mark choice.link as safe in the alphabet template

### DIFF
--- a/alphafilter/templates/alphafilter/alphabet.html
+++ b/alphafilter/templates/alphafilter/alphabet.html
@@ -1,3 +1,3 @@
 {% if choices %}<ul class="alphabetfilter">{% for choice in choices %}
-<li{% if forloop.first %} class="first"{% endif %}>{% if choice.has_entries %}<a href="{{ choice.link }}">{% else %}<span class="inactive">{% endif %}{% if choice.active %}<span class="selected">{% endif %}{{ choice.title }}{% if choice.active %}</span>{% endif %}{% if choice.has_entries %}</a>{% else %}</span>{% endif %}</li>{% endfor %}
+<li{% if forloop.first %} class="first"{% endif %}>{% if choice.has_entries %}<a href="{{ choice.link|safe }}">{% else %}<span class="inactive">{% endif %}{% if choice.active %}<span class="selected">{% endif %}{{ choice.title }}{% if choice.active %}</span>{% endif %}{% if choice.has_entries %}</a>{% else %}</span>{% endif %}</li>{% endfor %}
 </ul><br class="clear" />{% endif %}


### PR DESCRIPTION
This marks choices.link as safe in the template, to avoid escaping of "&" to "&amp;amp;" in the url.
