### PR TITLE
Use django querysets to fetch available letters

### DIFF
--- a/alphafilter/sql.py
+++ b/alphafilter/sql.py
@@ -1,0 +1,15 @@
+from django.db.models.sql import aggregates
+from django.db.models.aggregates import Aggregate
+
+
+class FirstLetterSQL(aggregates.Aggregate):
+    sql_template = 'UPPER(%(function)s(%(field)s, 1, 1))'
+    sql_function = 'SUBSTR'
+
+
+class FirstLetter(Aggregate):
+    name = 'FirstLetter'
+
+    def add_to_query(self, query, alias, col, source, is_summary):
+        aggregate = FirstLetterSQL(col, source=source, is_summary=is_summary, **self.extra)
+        query.aggregates[alias] = aggregate


### PR DESCRIPTION
Using raw SQL on the model table doesn't work on inherited models. For example:

```
class Worker(models.Model):
    name = models.CharField(max_lenght=100)

class Technician(Worker):
    description = models.TextField()
```

With this models alphafilter can't filter the technicians by their name.

Using django querysets (and a custom aggregation function) all necessary
table joins are made, and the executed SQL is not much worse:

For worker filtering:

```
'SELECT DISTINCT UPPER(SUBSTR("sample_worker"."name", 1, 1)) AS "fl" FROM "sample_worker" GROUP BY "sample_worker"."name"'
```

For Technician filtering:

```
'SELECT DISTINCT UPPER(SUBSTR("sample_worker"."title", 1, 1)) AS "fl" FROM "sample_technician" LEFT OUTER JOIN "sample_worker" ON ("sample_technician"."building_ptr_id" = "sample_worker"."id") GROUP BY "sample_worker"."title"'
```

Another benefit of this approach is that custom querysets can be used, to
get filtering on a subset of the table.
