### PR TITLE
Support for Django 1.9

### DIFF
--- a/alphafilter/admin.py
+++ b/alphafilter/admin.py
@@ -4,7 +4,12 @@ ALPHAFILTER_ADMIN_FIELDS and replaces it with a new admin class that
 subclasses both the original admin and one with an alphabet_filter attribute
 """
 
-from django.db.models import get_model
+try: # Django < 1.9
+	from django.db.models import get_model
+except ImportError: # Django 1.9+
+	from django.apps import apps
+	get_model = apps.get_model
+
 from django.contrib import admin
 from django.conf import settings
 


### PR DESCRIPTION
django.db.models.get_model() is removed in Django 1.9
replaced by django.apps.apps.get_model()